### PR TITLE
Add theme EuroZephyr

### DIFF
--- a/themes.txt
+++ b/themes.txt
@@ -1,3 +1,4 @@
+codeberg.org/gbilder/eurozephyr
 github.com/10mohi6/hugo-theme-simple-blog
 github.com/17ms/yuan
 github.com/1bl4z3r/hermit-V2


### PR DESCRIPTION
CV theme that supports the Europass standard

After you have read the [instructions for adding a theme](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#adding-a-theme), please make sure:

- [✅ ] your theme.toml [is complete](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#theme-configuration)
    - [✅ ] name
    - [ ✅] license
    - [✅ ] licenselink
    - [ ✅] description
    - [✅ ] homepage
    - [✅ ] demosite (if one exists)
    - [✅ ] tags
    - [ ✅] features
    - [✅ ] authors/author (depending on whether the theme has multiple or a single author)
    - [ N/A] original (if the theme is a fork)
- [N/A ] you're using [absolute paths for images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#use-absolute-paths-for-images) in your README
- [✅ ] you've got [appropriate thumbnail and screenshot images](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#media)
- [ ✅] your theme comes with an [appropriate license](https://github.com/gohugoio/hugoThemesSiteBuilder/blob/main/README.md#2-license)
